### PR TITLE
Expand and README and fix minor issues 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,16 @@
 Create an "Application credential" in OpenStack with the role "member" and download the `clouds.yaml` file into this directory.
 
-Edit the `main.tf` to change the `key_pair` to be the name of a key pair you have created in the OpenStack UI.
+Edit the `main.tf` to change the `key_pair` from `"my_key_pair_name"` to be the name of a key pair you have created in the OpenStack UI.
 
-Then run:
+Optionally edit `main.tf` to change the `name` of your instance from `"my-tf-test"` to something of your choosing.
+
+First run:
+
+```
+./terraform init
+```
+
+to initialize the Terraform working directory, and then
 
 ```
 HTTPS_PROXY=socks5://localhost:3128 ./terraform apply
@@ -10,8 +18,14 @@ HTTPS_PROXY=socks5://localhost:3128 ./terraform apply
 
 It will print out the IP address after applying.
 
-You can then SSH in with:
+You can then SSH in via the jump host with:
 
 ```
 ssh -J dl-admin-jump.acrc.bris.ac.uk cloud-user@the.ip.address.from.above
+```
+
+If you have your SSH private key stored on the VDI, you can SSH directly from a VDI session to the instance floating IP without specifying a jump host
+
+```
+ssh cloud-user@the.ip.address.from.above
 ```

--- a/main.tf
+++ b/main.tf
@@ -23,9 +23,10 @@ data "openstack_compute_flavor_v2" "m1_medium" {
 }
 
 resource "openstack_compute_instance_v2" "my_instance" {
-  name = "matt-tf-test"
+  name = "my-tf-test"
   flavor_id = data.openstack_compute_flavor_v2.m1_medium.id
   security_groups = ["default"]
+  key_pair = "my_key_pair_name"
 
   block_device {
     uuid = data.openstack_images_image_v2.rocky_9.id


### PR DESCRIPTION
Some edits and fixes for issues that arose while running the example. 

In `README.md`:

* More detail about editing `key_pair`
* Suggest edit to instance `name`
* Add `terraform init` step
* Add info about SSHing from VDI

In `main.tf`:

* Add key_pair argument to instance resource
* Make instance resource name generic